### PR TITLE
Add support for Claude Haiku 4.5

### DIFF
--- a/library/models/anthropic/claude-haiku-4-5-20251001.yaml
+++ b/library/models/anthropic/claude-haiku-4-5-20251001.yaml
@@ -1,0 +1,19 @@
+claude-haiku-4-5-20251001:
+  name: Claude Haiku 4.5 20251001
+  type: language
+  icon: https://claude.ai/favicon.ico
+  author: anthropic
+  description: Anthropic's fastest and most intelligent Haiku model, delivering near-frontier intelligence at blazing speeds with extended thinking and exceptional cost-efficiency.
+  website: https://www.anthropic.com/claude/haiku
+  providers:
+    - provider: anthropic
+      model: claude-haiku-4-5-20251001
+      context_window: 200000
+      max_tokens: 64000
+      pricing:
+        type: fixed
+        input: 1
+        output: 5
+        web_search: 0.01
+        input_cache_reads: 0.1
+        input_cache_writes: 1.25

--- a/library/models/anthropic/claude-haiku-4.5.yaml
+++ b/library/models/anthropic/claude-haiku-4.5.yaml
@@ -1,0 +1,19 @@
+anthropic/claude-haiku-4.5:
+  name: Claude Haiku 4.5
+  type: language
+  icon: https://claude.ai/favicon.ico
+  author: anthropic
+  description: Anthropic's fastest and most intelligent Haiku model, delivering near-frontier intelligence at blazing speeds with extended thinking and exceptional cost-efficiency.
+  website: https://www.anthropic.com/claude/haiku
+  providers:
+    - provider: anthropic
+      model: claude-haiku-4-5
+      context_window: 200000
+      max_tokens: 64000
+      pricing:
+        type: fixed
+        input: 1
+        output: 5
+        web_search: 0.01
+        input_cache_reads: 0.1
+        input_cache_writes: 1.25


### PR DESCRIPTION
## Summary
Add YAML configurations for Claude Haiku 4.5, Anthropic's fastest and most intelligent Haiku model.

## Changes
- Add `claude-haiku-4.5.yaml` (alias version)
- Add `claude-haiku-4-5-20251001.yaml` (snapshot version)

## Model Features
- **Context Window**: 200K tokens
- **Max Output**: 64K tokens
- **Extended Thinking**: Supported
- **Performance**: Near-frontier intelligence at blazing speeds
- **Cost-Efficiency**: $1/MTok input, $5/MTok output

## References
- [Anthropic Claude Haiku Documentation](https://www.anthropic.com/claude/haiku)
- [Anthropic News: Claude Haiku 4.5](https://www.anthropic.com/news/claude-haiku-4-5)
- [Model Overview](https://docs.anthropic.com/en/docs/about-claude/models/overview)