### PR TITLE
Add support for Claude Opus 4.5

### DIFF
--- a/library/models/anthropic/claude-opus-4-5-20251101.yaml
+++ b/library/models/anthropic/claude-opus-4-5-20251101.yaml
@@ -1,0 +1,19 @@
+claude-opus-4-5-20251101:
+  name: Claude Opus 4.5 20251101
+  type: language
+  icon: https://claude.ai/favicon.ico
+  author: anthropic
+  description: Anthropic's premium model combining maximum intelligence with practical performance, offering the highest level of reasoning and analysis capabilities.
+  website: https://docs.anthropic.com/en/docs/about-claude/models/overview
+  providers:
+    - provider: anthropic
+      model: claude-opus-4-5-20251101
+      context_window: 200000
+      max_tokens: 64000
+      pricing:
+        type: fixed
+        input: 5
+        output: 25
+        web_search: 0.01
+        input_cache_reads: 0.5
+        input_cache_writes: 6.25

--- a/library/models/anthropic/claude-opus-4.5.yaml
+++ b/library/models/anthropic/claude-opus-4.5.yaml
@@ -1,0 +1,19 @@
+anthropic/claude-opus-4.5:
+  name: Claude Opus 4.5
+  type: language
+  icon: https://claude.ai/favicon.ico
+  author: anthropic
+  description: Anthropic's premium model combining maximum intelligence with practical performance, offering the highest level of reasoning and analysis capabilities.
+  website: https://docs.anthropic.com/en/docs/about-claude/models/overview
+  providers:
+    - provider: anthropic
+      model: claude-opus-4-5
+      context_window: 200000
+      max_tokens: 64000
+      pricing:
+        type: fixed
+        input: 5
+        output: 25
+        web_search: 0.01
+        input_cache_reads: 0.5
+        input_cache_writes: 6.25


### PR DESCRIPTION
This PR introduces YAML configuration files for Anthropic's Claude Opus 4.5 model, adding both the alias version and the snapshot version with timestamp (20251101).

## Changes

- Added `library/models/anthropic/claude-opus-4.5.yaml` (alias version)
- Added `library/models/anthropic/claude-opus-4-5-20251101.yaml` (snapshot version)

## Model Features

- **Context Window:** 200K tokens
- **Max Output:** 64K tokens
- **Extended Thinking:** Supported
- **Positioning:** Premium model combining maximum intelligence with practical performance
- **Pricing:** $5/MTok input, $25/MTok output

## References

- [Anthropic Claude Opus Documentation](https://www.anthropic.com/claude/opus)
- [Claude Opus 4.5 Announcement](https://www.anthropic.com/news/claude-opus-4-5)
- [Claude Models Documentation](https://docs.anthropic.com/en/docs/about-claude/models/overview)