### PR TITLE
Add support for Claude Opus 4.6

### DIFF
--- a/library/models/anthropic/claude-opus-4.6.yaml
+++ b/library/models/anthropic/claude-opus-4.6.yaml
@@ -1,0 +1,30 @@
+anthropic/claude-opus-4.6:
+  name: Claude Opus 4.6
+  type: language
+  icon: https://claude.ai/favicon.ico
+  author: anthropic
+  description: Anthropic's most intelligent model for building agents and coding, featuring adaptive thinking, 1M context window, and 128K max output tokens.
+  website: https://www.anthropic.com/news/claude-opus-4-6
+  providers:
+    - provider: anthropic
+      model: claude-opus-4-6
+      context_window: 1000000
+      max_tokens: 128000
+      pricing:
+        type: tiered
+        tiers:
+          - predicate: { "<=": [{ "var": "input" }, 200000] }
+            pricing:
+              type: fixed
+              input: 5
+              output: 25
+              web_search: 0.01
+              input_cache_reads: 0.5
+              input_cache_writes: 6.25
+          - pricing:
+              type: fixed
+              input: 10
+              output: 37.5
+              web_search: 0.01
+              input_cache_reads: 1
+              input_cache_writes: 12.5


### PR DESCRIPTION
This PR introduces a YAML configuration file for Anthropic's Claude Opus 4.6 model.

## Changes

- Added `library/models/anthropic/claude-opus-4.6.yaml`

## Model Features

- **Context Window:** 1M tokens
- **Max Output:** 128K tokens
- **Adaptive Thinking:** Supported
- **Positioning:** Anthropic's most intelligent model for building agents and coding
- **Tiered Pricing:**
  - ≤200K context: $5/MTok input, $25/MTok output
  - >200K context: $10/MTok input, $37.50/MTok output

## Note

Currently only one model ID (`claude-opus-4-6`) is available — no snapshot version with a date suffix exists yet. A snapshot version file will be added once Anthropic publishes one.

## References

- [Claude Opus 4.6 Announcement](https://www.anthropic.com/news/claude-opus-4-6)
- [Claude Models Documentation](https://docs.anthropic.com/en/docs/about-claude/models/overview)